### PR TITLE
Fix public node

### DIFF
--- a/lib/endpoints/stats.js
+++ b/lib/endpoints/stats.js
@@ -39,7 +39,7 @@ async function getNodeStats (req, res, next) {
   res.contentType = 'application/json'
 
   // Check if Node UI has been made publicly available
-  if (req.headers['auth'] === '' && env.CHAINPOINT_NODE_UI_PASSWORD !== false) {
+  if (req.headers['auth'] === '' && env.CHAINPOINT_NODE_UI_PASSWORD !== 'false') {
     res.send(401, 'Unauthorized: Node is not Public. Please provide a valid authentication header value.')
     return next()
   }


### PR DESCRIPTION
When using `CHAINPOINT_NODE_UI_PASSWORD=false`, `env.CHAINPOINT_NODE_UI_PASSWORD` is actually a string, so the current condition doesn't work.

Could also be changed in https://github.com/chainpoint/chainpoint-node-src/blob/f88d99233c85bbf7f60037f26b4ba97b4cb7236d/lib/parse-env.js#L23-L25 as a new condition:
```
else if (x === 'false') {
  return false
}
```
or I guess:
```
else if (x.toLowerCase() === 'false') {
  return false
}
```