### PR TITLE
Make the docker image smaller and prepare for builds for other architectures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,45 +4,34 @@
 FROM node:8.11.3-stretch
 
 LABEL MAINTAINER="Glenn Rempe <glenn@tierion.com>"
+WORKDIR /home/node/app
+ENV NODE_ENV production
 
 # gosu : https://github.com/tianon/gosu
-RUN apt-get update && apt-get install -y git gosu
-
 # The `node` user and its home dir is provided by
 # the base image. Create a subdir where app code lives.
-RUN mkdir /home/node/app
-RUN mkdir /home/node/app/ui
+RUN apt-get update && \
+  apt-get install -y git gosu && \
+  mkdir -p /home/node/app/ui && \
+  mkdir -p /home/node/app/lib/{endpoints,models} && \
+  mkdir -p /home/node/app/keys/backups && \
+  mkdir -p /home/node/app/rocksdb
 
 # Copy Build Artifacts Node Stats UI
 COPY ./ui/build /home/node/app/ui
-
-WORKDIR /home/node/app
-
-ENV NODE_ENV production
-
 COPY package.json yarn.lock auth-keys-print.js server.js /home/node/app/
-RUN yarn
-
-RUN mkdir -p /home/node/app/lib
 COPY ./lib/*.js /home/node/app/lib/
-
-RUN mkdir -p /home/node/app/lib/endpoints
 COPY ./lib/endpoints/*.js /home/node/app/lib/endpoints/
-
-RUN mkdir -p /home/node/app/lib/models
 COPY ./lib/models/*.js /home/node/app/lib/models/
-
 COPY ./tor-exit-nodes.txt /home/node/app/
-
 COPY ./cert.crt /home/node/app/
 COPY ./cert.key /home/node/app/
 
-RUN mkdir -p /home/node/app/keys
-RUN mkdir -p /home/node/app/keys/backups
-RUN mkdir -p /home/node/app/rocksdb
+RUN yarn install --production && \
+  apt-get remove -y git && \
+  apt-get autoremove -y && \
+  rm -rf /var/lib/apt/lists/*
 
 EXPOSE 8080 8443
-
 ENTRYPOINT ["gosu", "node:node"]
-
 CMD ["yarn", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,6 @@ LABEL MAINTAINER="Glenn Rempe <glenn@tierion.com>"
 # gosu : https://github.com/tianon/gosu
 RUN apt-get update && apt-get install -y git gosu
 
-# Tini : https://github.com/krallin/tini
-ENV TINI_VERSION v0.18.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-#ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini.asc /tini.asc
-#RUN gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && gpg --verify /tini.asc
-RUN chown root:root /tini && chmod 755 /tini
-
 # The `node` user and its home dir is provided by
 # the base image. Create a subdir where app code lives.
 RUN mkdir /home/node/app
@@ -50,6 +43,6 @@ RUN mkdir -p /home/node/app/rocksdb
 
 EXPOSE 8080 8443
 
-ENTRYPOINT ["gosu", "node:node", "/tini", "--"]
+ENTRYPOINT ["gosu", "node:node"]
 
 CMD ["yarn", "start"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,14 +1,14 @@
-version: '2.1'
+version: '3.7'
 
 networks:
   chainpoint-node:
     driver: bridge
 
 services:
-
   chainpoint-node:
     image: gcr.io/chainpoint-registry/chainpoint-node:latest
     restart: on-failure
+    init: true
     volumes:
       - ./ip-blacklist.txt:/home/node/app/ip-blacklist.txt:ro
       - ./keys:/home/node/app/keys
@@ -26,4 +26,3 @@ services:
       CHAINPOINT_CORE_API_BASE_URI: "${CHAINPOINT_CORE_API_BASE_URI:-http://0.0.0.0}"
       CHAINPOINT_NODE_UI_PASSWORD: "${CHAINPOINT_NODE_UI_PASSWORD:-empty}"
       CHAINPOINT_NODE_REFLECTED_URI: "${CHAINPOINT_NODE_REFLECTED_URI:-empty}"
-      #DEBUG: "sequelize*"


### PR DESCRIPTION
## Prepare for other architectures

Simply remove the dependency on `tini` and replace it with Docker's `--init` flag. The same could be achieved by simply adding the right binary for each architecture, but this way the same `Dockerfile` can be used for all architectures.

This image was tested on `amd64` and `arm32v7` (Raspberry Pi, although it takes ~45 minutes to build the image).

## Make the Docker image smaller

- Reduce amount of layers
- Use `yarn install --production` (no need for `eslint`, `prettier` and those things in the final image)
- Remove `git` and clear `/var/lib/apt/lists/*`

I guess it would also be possible to remove all those dependencies: https://github.com/docker-library/buildpack-deps/blob/d7da72aaf3bb93fecf5fcb7c6ff154cb0c55d1d1/stretch/Dockerfile

## Alternative Alpine image

```Dockerfile
FROM node:alpine

LABEL MAINTAINER="Glenn Rempe <glenn@tierion.com>"
WORKDIR /home/node/app
ENV NODE_ENV production

# Install dependencies and create directories
RUN echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
  apk add --no-cache gosu@testing && \
  apk add --no-cache --virtual .build build-base linux-headers git python && \
  mkdir -p /home/node/app/keys/backups && \
  mkdir -p /home/node/app/rocksdb

# Copy all necessary JS files
COPY package.json yarn.lock auth-keys-print.js server.js tor-exit-nodes.txt cert.crt cert.key /home/node/app/
COPY lib /home/node/app/lib
COPY ui/build /home/node/app/ui

# Install NodeJS dependencies then remove build packages
RUN JOBS=max npm install --production && \
  apk del --no-cache .build

EXPOSE 8080
ENTRYPOINT ["gosu", "node:node"]
CMD ["yarn", "start"]
```

The issue with the Alpine version is that it doesn't support `arm32v7`, which was the whole point of all these changes (didn't get it to work with `arm32v6` on RPi, although it might have been my own fault now that I think about it - will try again).