### PR TITLE
Add alternative Dockerfile based on Alpine

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -15,6 +15,14 @@ RUN echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/ap
   mkdir -p /home/node/app/keys/backups && \
   mkdir -p /home/node/app/rocksdb && \
   JOBS=max npm install --production && \
+  \
+  # Clean rocksdb build dependencies
+  mv /home/node/app/node_modules/rocksdb/build/Release/leveldown.node /tmp/ && \
+  rm -r /home/node/app/node_modules/rocksdb/build/ && \
+  mkdir -p /home/node/app/node_modules/rocksdb/build/Release/ && \
+  mv /tmp/leveldown.node /home/node/app/node_modules/rocksdb/build/Release/ && \
+  \
+  # Remove Alpine build dependencies
   apk del --no-cache .build
 
 # Copy all necessary JS files

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -9,7 +9,7 @@ ENV NODE_ENV production
 COPY package.json yarn.lock /home/node/app/
 
 # Install dependencies and create directories
-RUN apk add --no-cache su-exec && \
+RUN apk add --no-cache su-exec tini && \
   apk add --no-cache --virtual .build build-base linux-headers git python && \
   mkdir -p keys/backups && \
   mkdir -p rocksdb && \
@@ -31,5 +31,5 @@ COPY lib /home/node/app/lib
 COPY ui/build /home/node/app/ui
 
 EXPOSE 8080
-ENTRYPOINT ["su-exec", "node:node"]
+ENTRYPOINT ["su-exec", "node:node", "tini", "--"]
 CMD ["yarn", "start"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -9,8 +9,7 @@ ENV NODE_ENV production
 COPY package.json yarn.lock /home/node/app/
 
 # Install dependencies and create directories
-RUN echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
-  apk add --no-cache gosu@testing && \
+RUN apk add --no-cache su-exec && \
   apk add --no-cache --virtual .build build-base linux-headers git python && \
   mkdir -p keys/backups && \
   mkdir -p rocksdb && \
@@ -32,5 +31,5 @@ COPY lib /home/node/app/lib
 COPY ui/build /home/node/app/ui
 
 EXPOSE 8080
-ENTRYPOINT ["gosu", "node:node"]
+ENTRYPOINT ["su-exec", "node:node"]
 CMD ["yarn", "start"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -30,6 +30,6 @@ COPY auth-keys-print.js server.js tor-exit-nodes.txt cert.crt cert.key ./
 COPY lib ./lib
 COPY ui/build ./ui
 
-EXPOSE 8080
+EXPOSE 8080 8443
 ENTRYPOINT ["su-exec", "node:node", "tini", "--"]
 CMD ["yarn", "start"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -6,7 +6,7 @@ ENV NODE_ENV production
 
 # Copy package.json first, build and then add other files.
 # This way there's no need to rebuild the whole thing if only a few JS files change
-COPY package.json yarn.lock /home/node/app/
+COPY package.json yarn.lock ./
 
 # Install dependencies and create directories
 RUN apk add --no-cache su-exec tini && \
@@ -19,16 +19,16 @@ RUN apk add --no-cache su-exec tini && \
   mv node_modules/rocksdb/build/Release/leveldown.node /tmp/ && \
   rm -r node_modules/rocksdb/build/ && \
   mkdir -p node_modules/rocksdb/build/Release/ && \
-  mv /tmp/leveldown.node /home/node/app/node_modules/rocksdb/build/Release/ && \
+  mv /tmp/leveldown.node node_modules/rocksdb/build/Release/ && \
   rm -r node_modules/rocksdb/deps && \
   \
   # Remove Alpine build dependencies
   apk del --no-cache .build
 
 # Copy all necessary JS files
-COPY auth-keys-print.js server.js tor-exit-nodes.txt cert.crt cert.key /home/node/app/
-COPY lib /home/node/app/lib
-COPY ui/build /home/node/app/ui
+COPY auth-keys-print.js server.js tor-exit-nodes.txt cert.crt cert.key ./
+COPY lib ./lib
+COPY ui/build ./ui
 
 EXPOSE 8080
 ENTRYPOINT ["su-exec", "node:node", "tini", "--"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,27 @@
+FROM node:alpine
+
+LABEL MAINTAINER="Glenn Rempe <glenn@tierion.com>"
+WORKDIR /home/node/app
+ENV NODE_ENV production
+
+# Copy package.json first, build and then add other files.
+# This way there's no need to rebuild the whole thing if only a few JS files change
+COPY package.json yarn.lock /home/node/app/
+
+# Install dependencies and create directories
+RUN echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
+  apk add --no-cache gosu@testing && \
+  apk add --no-cache --virtual .build build-base linux-headers git python && \
+  mkdir -p /home/node/app/keys/backups && \
+  mkdir -p /home/node/app/rocksdb && \
+  JOBS=max npm install --production && \
+  apk del --no-cache .build
+
+# Copy all necessary JS files
+COPY auth-keys-print.js server.js tor-exit-nodes.txt cert.crt cert.key /home/node/app/
+COPY lib /home/node/app/lib
+COPY ui/build /home/node/app/ui
+
+EXPOSE 8080
+ENTRYPOINT ["gosu", "node:node"]
+CMD ["yarn", "start"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:8.12.0-alpine
 
 LABEL MAINTAINER="Glenn Rempe <glenn@tierion.com>"
 WORKDIR /home/node/app

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -12,15 +12,16 @@ COPY package.json yarn.lock /home/node/app/
 RUN echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
   apk add --no-cache gosu@testing && \
   apk add --no-cache --virtual .build build-base linux-headers git python && \
-  mkdir -p /home/node/app/keys/backups && \
-  mkdir -p /home/node/app/rocksdb && \
+  mkdir -p keys/backups && \
+  mkdir -p rocksdb && \
   JOBS=max npm install --production && \
   \
   # Clean rocksdb build dependencies
-  mv /home/node/app/node_modules/rocksdb/build/Release/leveldown.node /tmp/ && \
-  rm -r /home/node/app/node_modules/rocksdb/build/ && \
-  mkdir -p /home/node/app/node_modules/rocksdb/build/Release/ && \
+  mv node_modules/rocksdb/build/Release/leveldown.node /tmp/ && \
+  rm -r node_modules/rocksdb/build/ && \
+  mkdir -p node_modules/rocksdb/build/Release/ && \
   mv /tmp/leveldown.node /home/node/app/node_modules/rocksdb/build/Release/ && \
+  rm -r node_modules/rocksdb/deps && \
   \
   # Remove Alpine build dependencies
   apk del --no-cache .build

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM node:8.12.0-alpine
+FROM node:10.13.0-alpine
 
 LABEL MAINTAINER="Glenn Rempe <glenn@tierion.com>"
 WORKDIR /home/node/app


### PR DESCRIPTION
This is a follow-up PR for #21 but only for Alpine. As it is a development file, I didn't add `tini`, but it should be as easy as running `apk add --no-cache tini` (it is available in the community repo: https://pkgs.alpinelinux.org/packages?name=tini&branch=v3.8).

I also changed the architecture of the Dockerfile a bit, and will open a separate PR to implement these changes in the current `Dockerfile` once this one is validated. Key changes:

- Use Alpine of course
- Build `rocksdb` with all cores instead of just one
- Reduce layers (only one huge RUN command, less COPY commands)
- Only install production `npm` packages
- No need to rebuild the whole image if `package.json` and `yarn.lock` don't change
- Remove almost all build dependencies

Regarding the `rocksdb` build artifacts, this might not be the cleanest way to remove them. My thinking is that I can't really build it in a build container and then move the file, because its `install` script would still try to build it: https://github.com/Level/rocksdb/blob/master/package.json#L44.

The resulting image is now 119MB instead of 1.04GB! 😄 