### PR TITLE
Fix `decodeCalendarTopBlockHeightValue`

### DIFF
--- a/lib/models/RocksDB.js
+++ b/lib/models/RocksDB.js
@@ -226,7 +226,7 @@ function encodeCalendarTopBlockHeightValue(topBlockHeight) {
 }
 
 function decodeCalendarTopBlockHeightValue(topBlockHeightValue) {
-  return topBlockHeightValue.readUInt32BE(topBlockHeightValue)
+  return topBlockHeightValue.readUInt32BE(0)
 }
 
 async function saveCalendarBlockBatchAsync(calendarBlocks) {


### PR DESCRIPTION
Maybe I'm missing something here, but an offset of 0 should work. As stated in #23:

```
$ docker run --rm -it node:alpine
> let buf = Buffer.from([0x00, 0x21, 0x6c, 0xa3])
> buf.readUInt32BE(buf)
TypeError [ERR_INVALID_ARG_TYPE]: The "offset" argument must be of type number. Received type object
    at checkNumberType (internal/buffer.js:42:11)
    at Buffer.readUInt32BE (internal/buffer.js:194:3)

$ docker run --rm -it node:8-alpine
> let buf = Buffer.from([0x00, 0x21, 0x6c, 0xa3]) 
undefined
> buf.readUInt32BE(buf)
2190499
```

A buffer obviously can't be an integer offset, right? I'm quite surprised that it worked on Node 8. In any case, it doesn't in Node 10 anymore.