### PR TITLE
WIP: Add CHAINPOINT_NODE_HMAC_KEY env var

### DIFF
--- a/lib/parse-env.js
+++ b/lib/parse-env.js
@@ -73,6 +73,12 @@ let envDefinitions = {
       'The CHAINPOINT_NODE_UI_PASSWORD is used to control access to the Node UI Dashboard.'
   }),
 
+  // Don't validate the HMAC here as it will use the same validation as keys parsed from files
+  CHAINPOINT_NODE_HMAC_KEY: envalid.str({
+    default: '',
+    desc: 'Use this HMAC key to register the node'
+  }),
+
   // Chainpoint Core
   CHAINPOINT_CORE_API_BASE_URI: validateCoreURI({
     default: 'http://0.0.0.0',


### PR DESCRIPTION
### Proposal

Add a `CHAINPOINT_NODE_HMAC_KEY` environment variable to make it easier to seed nodes, as everything can now be configured from a single place (at least if the node has been registered before).

This is a rough WIP to make sure we're on the same page.

A few more steps to do:

- [ ] Add `CHAINPOINT_NODE_HMAC_KEY` documentation to `.env.sample` and `docker-compose.yaml`
- [ ] Add `CHAINPOINT_NODE_HMAC_KEY` to https://github.com/chainpoint/chainpoint-node if merged

A few questions:

- [ ] Should we skip `authKeysUpdate` and/or `backupAuthKeysAsync` if the env var was provided? I guess I'd prefer to skip both of them, thoughts?
- [ ] What should I write in the logs (`logText`) for env var?

### Prettier

Not quite sure what's wrong with `prettier` yet as it changed some things automatically.